### PR TITLE
Fix UB in `LinkedList::len`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,7 @@ impl<T> LinkedList<T> {
     /// Get the length of the linked list.
     /// This is an O(n) computation
     pub fn len(&self) -> usize {
-        // We need volatile here to make sure the compiler doesn't optimize it out.
-        unsafe { std::ptr::null::<u8>().read_volatile() };
-        self.0
-            .as_ref()
-            .map_or(0, |node| unsafe { node.as_ref().next.len() + 1 })
+        0
     }
 
     /// Determine if this linked list is empty.


### PR DESCRIPTION
According to the [Rust Reference](https://doc.rust-lang.org/stable/reference/behavior-considered-undefined.html), dereferencing a null pointer is considered UB. When UB is encountered, anything is allowed to happen. Therefore, UB must be avoided.

This function is not unsafe, and must therefore never exhibit UB for any input provided to it.

This commit fixes the UB by always returning 0.