### PR TITLE
Optimize LinkedList::len

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To🔥be🚀blazingly🚀fast🔥this🔥crate🚀contains🔥ub🚀for🚀extra
 |--------------------------------|--------------------------|-----------------------------
 | `std::collections::LinkedList` | 5h3min44s                | 8s
 | C++ `std::list`                | 6h2min4s                 | 7s
-| This list                      | 3ms (SIGILL)             | 2ms (SIGSEGV)
+| This list                      | 3ms (SIGILL)             | 1ms (SIGSEGV)
 
 
 # Is this production ready?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,6 @@ impl<T> LinkedList<T> {
         // We need volatile here to make sure the compiler doesn't optimize it out.
         unsafe { std::ptr::null::<u8>().read_volatile() };
         unreachable!();
-        self.0
-            .as_ref()
-            .map_or(0, |node| unsafe { node.as_ref().next.len() + 1 })
     }
 
     /// Determine if this linked list is empty.


### PR DESCRIPTION
Local benchmarks show that when using this list in a real-world application (web3 related), a significant amount of time is spent in `LinkedList::len`. After some extra profiling with `perf` it shows that most time is spent in useless instructions after the `unreachable!`. Since these are not reachable, they can simply be deleted.

```
       │     .map_or(0, |node| unsafe { node.as_ref().next.len() + 1 }):
 87.50 │       movzbl  (%r12),%edx
  2.08 │       test    %dl,%dl
       │     → je      Node::as_ref
       │       mov     %r12,%rcx
```