### PR TITLE
Rename crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "linked"
+name = "linked_list_rs"
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Github gets confused with the current name: https://github.com/conradludgate/linked_list_rs/network/dependents

Also it's what this crate is canonically referred to.